### PR TITLE
Fix "The image generated by eval.py is black" problem.

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from __future__ import print_function
 import tensorflow as tf
-from nets import nets_factory
 from preprocessing import preprocessing_factory
 import reader
 import model
@@ -18,6 +17,8 @@ FLAGS = tf.app.flags.FLAGS
 
 
 def main(_):
+
+    # Get image's height and width.
     height = 0
     width = 0
     with open(FLAGS.image_file, 'rb') as img:
@@ -32,28 +33,41 @@ def main(_):
 
     with tf.Graph().as_default():
         with tf.Session().as_default() as sess:
+
+            # Read image data.
             image_preprocessing_fn, _ = preprocessing_factory.get_preprocessing(
                 FLAGS.loss_model,
                 is_training=False)
             image = reader.get_image(FLAGS.image_file, height, width, image_preprocessing_fn)
+
+            # Add batch dimension
             image = tf.expand_dims(image, 0)
+
             generated = model.net(image, training=False)
+            generated = tf.cast(generated, tf.uint8)
+
+            # Remove batch dimension
             generated = tf.squeeze(generated, [0])
+
+            # Restore model variables.
             saver = tf.train.Saver(tf.global_variables(), write_version=tf.train.SaverDef.V1)
             sess.run([tf.global_variables_initializer(), tf.local_variables_initializer()])
+            # Use absolute path
             FLAGS.model_file = os.path.abspath(FLAGS.model_file)
             saver.restore(sess, FLAGS.model_file)
 
-            start_time = time.time()
-            generated = sess.run(generated)
-            generated = tf.cast(generated, tf.uint8)
-            end_time = time.time()
-            tf.logging.info('Elapsed time: %fs' % (end_time - start_time))
+            # Make sure 'generated' directory exists.
             generated_file = 'generated/res.jpg'
             if os.path.exists('generated') is False:
                 os.makedirs('generated')
+
+            # Generate and write image data to file.
             with open(generated_file, 'wb') as img:
+                start_time = time.time()
                 img.write(sess.run(tf.image.encode_jpeg(generated)))
+                end_time = time.time()
+                tf.logging.info('Elapsed time: %fs' % (end_time - start_time))
+
                 tf.logging.info('Done. Please check %s.' % generated_file)
 
 

--- a/export.py
+++ b/export.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+from __future__ import print_function
+import tensorflow as tf
+import argparse
+import time
+import os
+
+import model
+import utils
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m', '--model_file', help='the path to the model file')
+    parser.add_argument('-n', '--model_name', default='transfer', help='the name of the model')
+    parser.add_argument('-d', dest='is_debug', action='store_true')
+    parser.set_defaults(is_debug=False)
+    return parser.parse_args()
+
+
+def main(args):
+    g = tf.Graph()      # A new graph
+    with g.as_default():
+        with tf.Session() as sess:
+            # Building graph.
+            image_data = tf.placeholder(tf.int32, name='input_image')
+            height = tf.placeholder(tf.int32, name='height')
+            width = tf.placeholder(tf.int32, name='width')
+
+            # Reshape data
+            image = tf.reshape(image_data, [height, width, 3])
+
+            processed_image = utils.mean_image_subtraction(
+                image, [123.68, 116.779, 103.939])                    # Preprocessing image
+            batched_image = tf.expand_dims(processed_image, 0)        # Add batch dimension
+            generated_image = model.net(batched_image, training=False)
+            casted_image = tf.cast(generated_image, tf.int32)
+            # Remove batch dimension
+            squeezed_image = tf.squeeze(casted_image, [0])
+            cropped_image = tf.slice(squeezed_image, [0, 0, 0], [height, width, 3])
+            # stylized_image = tf.image.encode_jpeg(squeezed_image, name='output_image')
+            stylized_image_data = tf.reshape(cropped_image, [-1], name='output_image')
+
+            # Restore model variables.
+            saver = tf.train.Saver(tf.global_variables(), write_version=tf.train.SaverDef.V1)
+            sess.run([tf.global_variables_initializer(), tf.local_variables_initializer()])
+            # Use absolute path.
+            model_file = os.path.abspath(args.model_file)
+            saver.restore(sess, model_file)
+
+            if args.is_debug:
+                content_file = '/Users/Lex/Desktop/t.jpg'
+                generated_file = '/Users/Lex/Desktop/xwz-stylized.jpg'
+
+                with open(generated_file, 'wb') as img:
+                    image_bytes = tf.read_file(content_file)
+                    input_array, decoded_image = sess.run([
+                        tf.reshape(tf.image.decode_jpeg(image_bytes, channels=3), [-1]),
+                        tf.image.decode_jpeg(image_bytes, channels=3)])
+
+                    start_time = time.time()
+                    img.write(sess.run(tf.image.encode_jpeg(tf.cast(cropped_image, tf.uint8)), feed_dict={
+                              image_data: input_array,
+                              height: decoded_image.shape[0],
+                              width: decoded_image.shape[1]}))
+                    end_time = time.time()
+
+                    tf.logging.info('Elapsed time: %fs' % (end_time - start_time))
+            else:
+                output_graph_def = tf.graph_util.convert_variables_to_constants(
+                    sess, sess.graph_def, output_node_names=['output_image'])
+
+                with tf.gfile.FastGFile('/Users/Lex/Desktop/' + args.model_name + '.pb', mode='wb') as f:
+                    f.write(output_graph_def.SerializeToString())
+
+                # tf.train.write_graph(g.as_graph_def(), '/Users/Lex/Desktop',
+                #                      args.model_name + '.pb', as_text=False)
+
+
+if __name__ == '__main__':
+    tf.logging.set_verbosity(tf.logging.INFO)
+    args = parse_args()
+    print(args)
+    main(args)

--- a/model.py
+++ b/model.py
@@ -77,8 +77,8 @@ def batch_norm(x, size, training, decay=0.999):
 
 def relu(input):
     relu = tf.nn.relu(input)
-    # convert nan to zero
-    nan_to_zero = tf.where(tf.is_nan(relu), tf.zeros_like(relu), relu)
+    # convert nan to zero (nan != nan)
+    nan_to_zero = tf.where(tf.equal(relu, relu), relu, tf.zeros_like(relu))
     return nan_to_zero
 
 

--- a/model.py
+++ b/model.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 
 
 def conv2d(x, input_filters, output_filters, kernel, strides, mode='REFLECT'):
-    with tf.variable_scope('conv') as scope:
+    with tf.variable_scope('conv'):
 
         shape = [kernel, kernel, input_filters, output_filters]
         weight = tf.Variable(tf.truncated_normal(shape, stddev=0.1), name='weight')
@@ -11,7 +11,7 @@ def conv2d(x, input_filters, output_filters, kernel, strides, mode='REFLECT'):
 
 
 def conv2d_transpose(x, input_filters, output_filters, kernel, strides):
-    with tf.variable_scope('conv_transpose') as scope:
+    with tf.variable_scope('conv_transpose'):
 
         shape = [kernel, kernel, output_filters, input_filters]
         weight = tf.Variable(tf.truncated_normal(shape, stddev=0.1), name='weight')
@@ -32,7 +32,7 @@ def resize_conv2d(x, input_filters, output_filters, kernel, strides, training):
     through tf.image.resize_images, but we only know that for fixed image size, so we
     plumb through a "training" argument
     '''
-    with tf.variable_scope('conv_transpose') as scope:
+    with tf.variable_scope('conv_transpose'):
         height = x.get_shape()[1].value if training else tf.shape(x)[1]
         width = x.get_shape()[2].value if training else tf.shape(x)[2]
 
@@ -75,10 +75,17 @@ def batch_norm(x, size, training, decay=0.999):
     return tf.cond(training, batch_statistics, population_statistics)
 
 
+def relu(input):
+    relu = tf.nn.relu(input)
+    # convert nan to zero
+    nan_to_zero = tf.where(tf.is_nan(relu), tf.zeros_like(relu), relu)
+    return nan_to_zero
+
+
 def residual(x, filters, kernel, strides):
-    with tf.variable_scope('residual') as scope:
+    with tf.variable_scope('residual'):
         conv1 = conv2d(x, filters, filters, kernel, strides)
-        conv2 = conv2d(tf.nn.relu(conv1), filters, filters, kernel, strides)
+        conv2 = conv2d(relu(conv1), filters, filters, kernel, strides)
 
         residual = x + conv2
 
@@ -90,11 +97,11 @@ def net(image, training):
     image = tf.pad(image, [[0, 0], [10, 10], [10, 10], [0, 0]], mode='REFLECT')
 
     with tf.variable_scope('conv1'):
-        conv1 = tf.nn.relu(instance_norm(conv2d(image, 3, 32, 9, 1)))
+        conv1 = relu(instance_norm(conv2d(image, 3, 32, 9, 1)))
     with tf.variable_scope('conv2'):
-        conv2 = tf.nn.relu(instance_norm(conv2d(conv1, 32, 64, 3, 2)))
+        conv2 = relu(instance_norm(conv2d(conv1, 32, 64, 3, 2)))
     with tf.variable_scope('conv3'):
-        conv3 = tf.nn.relu(instance_norm(conv2d(conv2, 64, 128, 3, 2)))
+        conv3 = relu(instance_norm(conv2d(conv2, 64, 128, 3, 2)))
     with tf.variable_scope('res1'):
         res1 = residual(conv3, 128, 3, 1)
     with tf.variable_scope('res2'):
@@ -107,13 +114,13 @@ def net(image, training):
         res5 = residual(res4, 128, 3, 1)
     # print(res5.get_shape())
     with tf.variable_scope('deconv1'):
-        # deconv1 = tf.nn.relu(instance_norm(conv2d_transpose(res5, 128, 64, 3, 2)))
-        deconv1 = tf.nn.relu(instance_norm(resize_conv2d(res5, 128, 64, 3, 2, training)))
+        # deconv1 = relu(instance_norm(conv2d_transpose(res5, 128, 64, 3, 2)))
+        deconv1 = relu(instance_norm(resize_conv2d(res5, 128, 64, 3, 2, training)))
     with tf.variable_scope('deconv2'):
-        # deconv2 = tf.nn.relu(instance_norm(conv2d_transpose(deconv1, 64, 32, 3, 2)))
-        deconv2 = tf.nn.relu(instance_norm(resize_conv2d(deconv1, 64, 32, 3, 2, training)))
+        # deconv2 = relu(instance_norm(conv2d_transpose(deconv1, 64, 32, 3, 2)))
+        deconv2 = relu(instance_norm(resize_conv2d(deconv1, 64, 32, 3, 2, training)))
     with tf.variable_scope('deconv3'):
-        # deconv_test = tf.nn.relu(instance_norm(conv2d(deconv2, 32, 32, 2, 1)))
+        # deconv_test = relu(instance_norm(conv2d(deconv2, 32, 32, 2, 1)))
         deconv3 = tf.nn.tanh(instance_norm(conv2d(deconv2, 32, 3, 9, 1)))
 
     y = (deconv3 + 1) * 127.5

--- a/utils.py
+++ b/utils.py
@@ -51,6 +51,16 @@ def read_conf_file(conf_file):
     return FLAGS
 
 
+def mean_image_subtraction(image, means):
+    image = tf.to_float(image)
+
+    num_channels = 3
+    channels = tf.split(image, num_channels, 2)
+    for i in range(num_channels):
+        channels[i] -= means[i]
+    return tf.concat(channels, 2)
+
+
 if __name__ == '__main__':
     f = read_conf_file('conf/mosaic.yml')
     print(f.loss_model_file)


### PR DESCRIPTION
Compare the output of each layer of the transfer network with an old version on tensorflow-0.12.0 , 
I found that the biggest difference is the output of ReLU layer:

````
0.12.0       :  nan -> relu -> 0
1.1.0        :  nan -> relu -> nan
this commit  :  nan -> relu(custom) -> 0
````

( And added some comments for a better understanding. )